### PR TITLE
Rename the 'Code Style' sections to 'Code Style & Documentation' for PHP and JS

### DIFF
--- a/_includes/markdown/JavaScript.md
+++ b/_includes/markdown/JavaScript.md
@@ -165,9 +165,11 @@ jQuery( '.menu' ).on( 'click', function() {
 Another example in JavaScript is ```escape()``` and ```unescape()```. These functions were deprecated. Instead we should use ```encodeURI()```, ```encodeURIComponent()```, ```decodeURI()```, and ```decodeURIComponent()```.
 
 
-<h3 id="js-code-style">Code Style</h3>
+<h3 id="js-code-style">Code Style & Documentation</h3>
 
 We conform to [WordPress JavaScript coding standards](http://make.wordpress.org/core/handbook/coding-standards/javascript/).
+
+In the absence of an adopted core standard for JavaScript documentation, we follow the [JSDoc3](http://usejsdoc.org/) standards.
 
 <h3 id="js-unit-testing">Unit and Integration Testing</h3>
 

--- a/_includes/markdown/PHP.md
+++ b/_includes/markdown/PHP.md
@@ -513,9 +513,9 @@ if ( ! empty( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'my_a
 ?>
 ```
 
-<h3 id="php-code-style">Code Style</h3>
+<h3 id="php-code-style">Code Style & Documentation</h3>
 
-We follow the [WordPress coding standards](http://make.wordpress.org/core/handbook/coding-standards/php/).
+We follow the official WordPress [coding](http://make.wordpress.org/core/handbook/coding-standards/php/) and [documentation](https://make.wordpress.org/core/handbook/inline-documentation-standards/php-documentation-standards/) standards.
 
 <h3 id="php-unit-testing">Unit and Integration Testing</h3>
 

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ layout: default
 			<li><a href="#php-design-patterns">Design Patterns</a></li>
 			<li><a href="#php-security">Security</a></li>
 			<li><a href="#php-unit-testing">Unit and Integration Testing</a></li>
-			<li><a href="#php-code-style">Code Style</a></li>
+			<li><a href="#php-code-style">Code Style & Documentation</a></li>
 			<li><a href="#php-libraries">Libraries and Frameworks</a></li>
 		</ul>
 		<h4><a href="#version-control">Version Control</a></h4>
@@ -36,7 +36,7 @@ layout: default
 			<li><a href="#js-performance">Performance</a></li>
 			<li><a href="#js-design-patterns">Design Patterns</a></li>
 			<li><a href="#js-unit-testing">Unit and Integration Testing</a></li>
-			<li><a href="#js-code-style">Code Style</a></li>
+			<li><a href="#js-code-style">Code Style & Documentation</a></li>
 			<li><a href="#js-libraries">Libraries</a></li>
 		</ul>
 		<h4><a href="#tools">Tools</a></h4>


### PR DESCRIPTION
Adds links to the WordPress documentation standards for PHP and the JSDoc3 standard for JavaScript. This fixes #11 
