### PR TITLE
WordPress Coding Standards for PHP_CodeSniffer

### DIFF
--- a/_includes/markdown/PHP.md
+++ b/_includes/markdown/PHP.md
@@ -559,7 +559,7 @@ if ( ! empty( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'my_a
 
 <h3 id="code-style">Code Style & Documentation {% include Util/top %}</h3>
 
-We follow the official WordPress [coding](http://make.wordpress.org/core/handbook/coding-standards/php/) and [documentation](https://make.wordpress.org/core/handbook/inline-documentation-standards/php-documentation-standards/) standards.
+We follow the official WordPress [coding](http://make.wordpress.org/core/handbook/coding-standards/php/) and [documentation](https://make.wordpress.org/core/handbook/inline-documentation-standards/php-documentation-standards/) standards. The [WordPress Coding Standards for PHP_CodeSniffer](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) will find many common violations and flag risky code for manual review.
 
 <h3 id="unit-testing">Unit and Integration Testing {% include Util/top %}</h3>
 


### PR DESCRIPTION
Link to [WordPress Coding Standards for PHP_CodeSniffer](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards).
