### PR TITLE
possible fix for h3 titles being hidden by navbar

### DIFF
--- a/_includes/_sass/includes/_docs-section.scss
+++ b/_includes/_sass/includes/_docs-section.scss
@@ -4,6 +4,11 @@
 	margin: 0 auto;
 }
 
+.docs-section h3 {
+	padding-top:80px;
+	margin-top:-80px;
+}
+
 .back-to-top {
 	font-size: 0.5em;
 }


### PR DESCRIPTION
The h3 titles on each of the pages are covered by the navbar across the top. I thought this might be a simple solution.
