### PR TITLE
WP_Query doesn't call get_posts()

### DIFF
--- a/_includes/markdown/PHP.md
+++ b/_includes/markdown/PHP.md
@@ -23,7 +23,7 @@ new WP_Query( array(
 
 * Do not use ```$wpdb``` or ```get_posts()``` unless you have good reason.
 
-```WP_Query``` actually calls ```get_posts()```; calling ```get_posts()``` directly bypasses a number of filters. Not sure whether you need these things or not? You probably don't.
+```get_posts()``` actually calls ```WP_Query```, but calling ```get_posts()``` directly bypasses a number of filters by default. Not sure whether you need these things or not? You probably don't.
 
 * If you don't plan to paginate query results, always pass ```no_found_rows => true``` to ```WP_Query```.
 


### PR DESCRIPTION
`WP_Query` doesn't call `get_posts()`, it's the other way round. `get_posts()` creates a new `WP_Query` object and indeed defaults `suppress_filters` to `true`. There's a gotcha too. If you need a list of posts in a widget, `WP_Query` will prepend sticky posts by default, which may or may not be intended behavior, while `get_posts()` defaults to `ignore_sticky_posts`.
