### PR TITLE
wp_nonce_field instead of wp_create_nonce

### DIFF
--- a/_includes/markdown/PHP.md
+++ b/_includes/markdown/PHP.md
@@ -541,7 +541,7 @@ Here is some example code for creating a nonce:
 
 ```php
 <form method="post" action="">
-    <?php wp_create_nonce( 'my_action_name' ); ?>
+    <?php wp_nonce_field( 'my_action_name' ); ?>
     ...
 </form>
 ```


### PR DESCRIPTION
If you want to output a nonce field, you're using the wrong function.
