### PR TITLE
Reverting to specified base protocol.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,6 @@ redcarpet:
 sass:
   sass_dir: _includes/_sass
 CONFIG:
-  BASE_PATH: //10up.github.io/Engineering-Best-Practices
+  BASE_PATH: https://10up.github.io/Engineering-Best-Practices
 
   ASSET_PATH: false


### PR DESCRIPTION
Using protocol agnostic base calls causes FOUC with the Javascript protocol detection. There's a disconnect between when the browser starts receiving data and when it recognizes that the protocol is https, causing it to flush its contents as it redirects.

Since we want to force SSL, I'm reverting to a specified base protocol (https) in the config files. This will make all calls explicitly to https:, removing that disconnect.
