### PR TITLE
CSS: Add a blank line before the inheritance code block.

### DIFF
--- a/_includes/markdown/CSS.md
+++ b/_includes/markdown/CSS.md
@@ -273,6 +273,7 @@ Avoid:
 ```
 
 Prefer:
+
 ```css
 .parent {
 	font-family: Arial, sans-serif;


### PR DESCRIPTION
See the following screenshot from https://10up.github.io/Engineering-Best-Practices/css/#inheritance

![CSS Inheritance](https://cloud.githubusercontent.com/assets/617637/7455394/1fddbd86-f27c-11e4-8c97-a61ac23b7bf5.png)
