### PR TITLE
Update link to correct page on WordPress core handbook.

### DIFF
--- a/_includes/markdown/JavaScript.md
+++ b/_includes/markdown/JavaScript.md
@@ -169,7 +169,7 @@ Another example in JavaScript is ```escape()``` and ```unescape()```. These func
 
 We conform to [WordPress JavaScript coding standards](http://make.wordpress.org/core/handbook/coding-standards/javascript/).
 
-We conform to the [WordPress JavaScript Documentation Standards](https://make.wordpress.org/core/handbook/inline-documentation-standards/javascript-documentation-standards/).
+We conform to the [WordPress JavaScript Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/).
 
 <h3 id="unit-and-integration-testing">Unit and Integration Testing {% include Util/top %}</h3>
 


### PR DESCRIPTION
Updated dead link regarding inline JavaScript documentation.

https://10up.github.io/Engineering-Best-Practices/javascript/#code-style
