### PR TITLE
Avoiding hooks in class constructor

### DIFF
--- a/_includes/markdown/PHP.md
+++ b/_includes/markdown/PHP.md
@@ -397,7 +397,7 @@ In terms of [Object-Oriented Programming](http://en.wikipedia.org/wiki/Object-or
 * Class inheritance should be used where possible to produce [DRY](http://en.wikipedia.org/wiki/Don't_repeat_yourself) code and share previously-developed components throughout the application.
 * Global variables should be avoided. If objects need to be passed throughout the theme or plugin, those objects should either be passed as parameters or referenced through an object factory.
 * Hidden dependencies (API functions, super-globals, etc) should be documented in the docblock of every function/method or property.
-* Avoid registering hooks in the __construct method. Doing so tightly couples the hooks to the instantiation of the class and is less flexible than doing so in a separate method. Unit testing becomes much more difficult as well.
+* Avoid registering hooks in the __construct method. Doing so tightly couples the hooks to the instantiation of the class and is less flexible than registering the hooks via a separate method. Unit testing becomes much more difficult as well.
 
 <h3 id="security">Security {% include Util/top %}</h3>
 

--- a/_includes/markdown/PHP.md
+++ b/_includes/markdown/PHP.md
@@ -397,6 +397,7 @@ In terms of [Object-Oriented Programming](http://en.wikipedia.org/wiki/Object-or
 * Class inheritance should be used where possible to produce [DRY](http://en.wikipedia.org/wiki/Don't_repeat_yourself) code and share previously-developed components throughout the application.
 * Global variables should be avoided. If objects need to be passed throughout the theme or plugin, those objects should either be passed as parameters or referenced through an object factory.
 * Hidden dependencies (API functions, super-globals, etc) should be documented in the docblock of every function/method or property.
+* Avoid registering hooks in the __construct method. Doing so tightly couples the hooks to the instantiation of the class and is less flexible than doing so in a separate method. Unit testing becomes much more difficult as well.
 
 <h3 id="security">Security {% include Util/top %}</h3>
 


### PR DESCRIPTION
Adding a note about avoiding adding hooks in the constructor of a class and suggesting a separate init method. Not sure if this is too prescriptive but I think it should be noted because it makes unit testing the code much more difficult as it would require WordPress to be loaded or the actions to be mocked.
