### PR TITLE
Minor Tidy Up

### DIFF
--- a/_includes/markdown/PHP.md
+++ b/_includes/markdown/PHP.md
@@ -71,7 +71,7 @@ Here are a few key points:
     endif;
     ?>
     ```
-    
+
     Instead of:
 
     ```php
@@ -82,10 +82,10 @@ Here are a few key points:
         'post__not_in' => $posts_to_exclude
     ) );
     ?>
-    ```	
-    
+    ```
+
     See [WordPress VIP](https://vip.wordpress.com/documentation/performance-improvements-by-removing-usage-of-post__not_in/).
-    
+
 * A [taxonomy](http://codex.wordpress.org/Taxonomies) is a tool that lets us group or classify posts.
 
     [Post meta](http://codex.wordpress.org/Custom_Fields) lets us store unique information about specific posts. As such the way post meta is stored does not facilitate efficient post lookups. Generally, looking up posts by post meta should be avoided (sometimes it can't). If you have to use one, make sure that it's not the main query and that it's cached.
@@ -340,7 +340,7 @@ Writing information to the database is at the core of any website you build. Her
 
 * When multiple threads (or page requests) read or write to a shared location in memory and the order of those read or writes is unknown, you have what is known as a [race condition](http://en.wikipedia.org/wiki/Race_condition).
 
-* Store information in the correct place. See the "Appropriate Data Storage" section.
+* Store information in the correct place. See the "[Appropriate Data Storage](#appropriate-data-storage)" section.
 
 * Certain options are "autoloaded" or put into the object cache on each page load. When [creating or updating options](http://codex.wordpress.org/Options_API), you can pass an ```$autoload``` argument to [```add_option()```](https://developer.wordpress.org/reference/functions/add_option/). If your option is not going to get used often, it probably shouldn't be autoloaded. Unfortunately, [```update_option()```](https://developer.wordpress.org/reference/functions/update_option/) automatically sets ```autoload``` to ```true``` so you have to use a combination of [```delete_option()```](https://developer.wordpress.org/reference/functions/delete_option/) and ```add_option()``` to accomplish this.
 
@@ -629,12 +629,12 @@ Example:
 /**
  * Hook into WordPress to mark specific post meta keys as protected
  *
- * Post meta can be either public or protected. Any post meta which holds 
+ * Post meta can be either public or protected. Any post meta which holds
  * **internal or read only** data should be protected via a prefixed underscore on
- * the meta key (ex: _my_post_meta) or by indicating it's protected via the 
- * is_protected_meta filter. 
+ * the meta key (ex: _my_post_meta) or by indicating it's protected via the
+ * is_protected_meta filter.
  *
- * Note, a meta field that is intended to be a viewable component of the post 
+ * Note, a meta field that is intended to be a viewable component of the post
  * (Examples: event date, or employee title) should **not** be protected.
  */
 add_filter( 'is_protected_meta', 'protect_post_meta', 10, 2 );
@@ -642,7 +642,7 @@ add_filter( 'is_protected_meta', 'protect_post_meta', 10, 2 );
 /**
  * Protect non-public meta keys
  *
- * Flag some post meta keys as private so they're not exposed to the public 
+ * Flag some post meta keys as private so they're not exposed to the public
  * via the Custom Fields meta box or the JSON REST API.
  *
  * @internal                          Called via is_protected_meta filter.
@@ -651,7 +651,7 @@ add_filter( 'is_protected_meta', 'protect_post_meta', 10, 2 );
  * @return   bool   $protected        The (possibly) modified $protected variable
  */
 function protect_post_meta( $protected, $current_meta_key ) {
-    
+
     // Assemble an array of post meta keys to be protected
     $meta_keys_to_be_protected = array(
         'my_meta_key',

--- a/_includes/markdown/Version-Control.md
+++ b/_includes/markdown/Version-Control.md
@@ -30,7 +30,7 @@ All theme projects will treat the ```master``` branch as the canonical source fo
 
 All staging branches will branch off ```master``` as well, and should be named ```staging``` or ```stage-{environment}``` for consistency and clarity. Staging branches will never be merged into any other branches. The ```master``` branch can be merged into both staging and feature branches to keep them up-to-date.
 
-###### Complex Feature Branches
+##### Complex Feature Branches
 
 In some cases, a feature will be large enough to warrant multiple developers working on it at the same time. In order to enable testing the feature as a cohesive unit and avoid merge conflicts when pushing to ```staging``` and ```master``` it is recommended to create a feature branch to act as a staging area. We do this by branching from ```master``` to create the primary feature branch, and then as necessary, create additional branches from the feature branch for distinct items of work. When individual items are complete, merge back to the feature branch. To pull work from ```master```, merge ```master``` into the feature branch and then merge the feature branch into the individual branches. When all work has been merged back into the feature branch, the feature branch can then be merged into ```staging``` and ```master``` as an entire unit of work.
 


### PR DESCRIPTION
1. Added a internal page link for the PHP page to jump from the _Database Writes_ section to the mentioned _Appropriate Data Storage_ section
2. Cleaned up extra white space and empty tabs in the PHP.md file
3. Removed an extra hash mark from the Version-Control.md file where _Complex Feature Branches_ was rendering too small.
