### PR TITLE
Fix to bug "esc_js() description is inaccurate"

### DIFF
--- a/_includes/markdown/PHP.md
+++ b/_includes/markdown/PHP.md
@@ -533,14 +533,26 @@ Here is another example:
 Here is another example:
 
 ```php
+<input type="text" onfocus="if( this.value == '<?php echo esc_js( $fields['input_text'] ); ?>' ) { this.value = ''; }" name="name">
+```
+
+[```esc_js()```](https://developer.wordpress.org/reference/functions/esc_js/) ensures that whatever is returned is safe to be printed within a JavaScript string. This function is intended to be used for inline JS, inside a tag attribute  (onfocus="...", for example).
+
+We should not be writting JavaScript inside tag attributes anymore, this means that ```esc_js()``` should never be used. To escape strings for JS another function should be used.
+
+Here is another example:
+
+```php
 <script>
 if ( document.cookie.indexOf( 'cookie_key' ) >= 0 ) {
-    document.getElementById( 'test' ).getAttribute( 'href' ) = '<?php echo esc_js( get_post_meta( $post_id, 'key', true ) ); ?>';
+document.getElementById( 'test' ).getAttribute( 'href' ) = <?php echo wp_json_encode( get_post_meta( $post_id, 'key', true ) ); ?>;
 }
 </script>
 ```
 
-[```esc_js()```](https://developer.wordpress.org/reference/functions/esc_js/) ensures that whatever is returned is safe to be printed within a JavaScript string.
+[```wp_json_encode()```](https://developer.wordpress.org/reference/functions/wp_json_encode/) ensures that whatever is returned is safe and returns a JSON encoded string to be used in your JavaScript code. 
+
+Note that ```wp_json_encode()``` includes the string-delimiting quotes for you.
 
 Sometimes you need to escape data that is meant to serve as an attribute. For that, you can use ```esc_attr()``` to ensure output only contains characters appropriate for an attribute:
 

--- a/_includes/markdown/PHP.md
+++ b/_includes/markdown/PHP.md
@@ -550,7 +550,7 @@ document.getElementById( 'test' ).getAttribute( 'href' ) = <?php echo wp_json_en
 </script>
 ```
 
-[```wp_json_encode()```](https://developer.wordpress.org/reference/functions/wp_json_encode/) ensures that whatever is returned is safe and returns a JSON encoded string to be used in your JavaScript code. 
+[```wp_json_encode()```](https://developer.wordpress.org/reference/functions/wp_json_encode/) ensures that whatever is returned is safe to be printed in your JavaScript code. It returns a JSON encoded string. 
 
 Note that ```wp_json_encode()``` includes the string-delimiting quotes for you.
 


### PR DESCRIPTION
A better description is given to when using esc_js is correct and what use instead when you want to print a safe string to be used in your JS code (wp_json_encode).
