### PR TITLE
Add Variable VVV for site creation.

### DIFF
--- a/_includes/markdown/Tools.md
+++ b/_includes/markdown/Tools.md
@@ -8,9 +8,11 @@ At 10up, we use [Vagrant](https://www.vagrantup.com/) to build and interact with
 
 [VIP Quickstart](https://github.com/Automattic/vip-quickstart) - A Vagrant setup meant to closely match the WordPress.com VIP environment. If you are working on a VIP project, it is good to have this installed to effectively test your website locally. We only recommend this Vagrant setup for VIP projects.
 
+[Variable VVV - a VVV Site Creation Wizard](https://github.com/bradp/vv) - vv makes it extremely easy to create a new WordPress site using Varying Vagrant Vagrants. vv supports site creation with many different options, including multisite, loading images from live site, and an initial database import.
+
 <h3 id="task-runners">Task Runners {% include Util/top %}</h3>
 
-[Grunt](http://gruntjs.com/) - Grunt is a task runner built on Node that lets you automate tasks like Sass preprocessing and JS minification. Grunt is the only task runner we currently use on company and client projects.
+[Grunt](http://gruntjs.com/) - Grunt is a task runner built on Node that lets you automate tasks like Sass preprocessing and JS minification. Grunt is the only taskrunner we currently use on company and client projects.
 
 <h3 id="package-managers">Package/Dependency Managers</h3>
 
@@ -27,5 +29,3 @@ At 10up, we use [Vagrant](https://www.vagrantup.com/) to build and interact with
 <h3 id="command-line">Command Line Tools</h3>
 
 [WP-CLI](http://wp-cli.org) - A command line interface for WordPress. This is an extremely powerful tool that allows us to do imports, exports, run custom scripts, and more via the command line. Often this is the only way we can affect a large database (WordPress.com VIP or WPEngine). This tool is installed by default on VVV and VIP Quickstart.
-
-

--- a/_includes/markdown/Tools.md
+++ b/_includes/markdown/Tools.md
@@ -12,7 +12,7 @@ At 10up, we use [Vagrant](https://www.vagrantup.com/) to build and interact with
 
 <h3 id="task-runners">Task Runners {% include Util/top %}</h3>
 
-[Grunt](http://gruntjs.com/) - Grunt is a task runner built on Node that lets you automate tasks like Sass preprocessing and JS minification. Grunt is the only taskrunner we currently use on company and client projects.
+[Grunt](http://gruntjs.com/) - Grunt is a task runner built on Node that lets you automate tasks like Sass preprocessing and JS minification. Grunt is the only task runner we currently use on company and client projects.
 
 <h3 id="package-managers">Package/Dependency Managers</h3>
 


### PR DESCRIPTION
I find this to be the easiest methods to create new sites in VVV.

The only concern I have with adding this as a recommendation is the default method for hooking up git repositories is by targeting wp-content, which doesn't follow our standard practice.
