### PR TITLE
Manage WP Plugins w/ Composer

### DIFF
--- a/_includes/markdown/Tools.md
+++ b/_includes/markdown/Tools.md
@@ -22,7 +22,7 @@ At 10up, we use [Vagrant](https://www.vagrantup.com/) and/or [Docker](https://ww
 
 [Composer](https://getcomposer.org) - We use Composer for managing PHP dependencies. Usually everything we need is bundled with WordPress, but sometimes we need external PHP libraries like "Patchwork". Composer is a great way to manage those external libraries.
 
-WordPress plugins in a project should be managed by Composer. Plugin versions can be easily managed in a single composer.json file and provides a central way to keep plugin versions between environments in sync. [WordPress Packagist](https://wpackagist.org/) provides a Composer repository that mirrors all public WordPress plugins and themes.
+WordPress plugins in a project should be managed by Composer. Plugin versions can be easily managed in a single composer.json, helping ensure plugin versions between environments are in sync. [WordPress Packagist](https://wpackagist.org/) provides a Composer repository that mirrors all public WordPress plugins and themes.
 
 <h2 id="version-control">Version Control {% include Util/top %}</h2>
 

--- a/_includes/markdown/Tools.md
+++ b/_includes/markdown/Tools.md
@@ -20,7 +20,9 @@ At 10up, we use [Vagrant](https://www.vagrantup.com/) and/or [Docker](https://ww
 
 [Bower](https://bower.io/) - A good tool to manage front end packages. Usually everything we need is bundled with WordPress. Sometimes we need something like "Chosen.js" that isn’t included. Bower is a good way to manage external libraries like that but is not necessary on most projects.
 
-[Composer](https://getcomposer.org) - We use Composer for managing PHP dependencies. Usually everything we need is bundled with WordPress. Sometimes we need external libraries like "Patchwork". Composer is a great way to manage those external libraries but is not necessary on most projects.
+[Composer](https://getcomposer.org) - We use Composer for managing PHP dependencies. Usually everything we need is bundled with WordPress, but sometimes we need external PHP libraries like "Patchwork". Composer is a great way to manage those external libraries.
+
+WordPress plugins in a project should be managed by Composer. Plugin versions can be easily managed in a single composer.json file and provides a central way to keep plugin versions between environments in sync. [WordPress Packagist](https://wpackagist.org/) provides a Composer repository that mirrors all public WordPress plugins and themes.
 
 <h2 id="version-control">Version Control {% include Util/top %}</h2>
 

--- a/_includes/markdown/Tools.md
+++ b/_includes/markdown/Tools.md
@@ -22,7 +22,7 @@ At 10up, we use [Vagrant](https://www.vagrantup.com/) and/or [Docker](https://ww
 
 [Composer](https://getcomposer.org) - We use Composer for managing PHP dependencies. Usually everything we need is bundled with WordPress, but sometimes we need external PHP libraries like "Patchwork". Composer is a great way to manage those external libraries.
 
-WordPress plugins in a project should be managed by Composer. Plugin versions can be easily managed in a single composer.json, helping ensure plugin versions between environments are in sync. [WordPress Packagist](https://wpackagist.org/) provides a Composer repository that mirrors all public WordPress plugins and themes.
+When a WordPress install is managed and maintained by an engineering team, and when the infrastructure supports it, plugins in a WordPress project can be easily managed using Composer. [WordPress Packagist](https://wpackagist.org/) provides a Composer repository that mirrors all public WordPress plugins and themes.
 
 <h2 id="version-control">Version Control {% include Util/top %}</h2>
 


### PR DESCRIPTION
Added recommendations to manage WordPress plugins with Composer as part of the best practices. While we could eventually go into greater detail to describe implementation, at least mentioning this as a best practice would be helpful for now.