### PR TITLE
Remove Bower from recommended Tools

### DIFF
--- a/_includes/markdown/Tools.md
+++ b/_includes/markdown/Tools.md
@@ -22,8 +22,6 @@ At 10up, we use [Vagrant](https://www.vagrantup.com/) and/or [Docker](https://ww
 
 <h2 id="package-managers">Package/Dependency Managers {% include Util/top %}</h2>
 
-[Bower](https://bower.io/) - A good tool to manage front end packages. Usually everything we need is bundled with WordPress. Sometimes we need something like "Chosen.js" that isn’t included. Bower is a good way to manage external libraries like that but is not necessary on most projects.
-
 [Composer](https://getcomposer.org) - We use Composer for managing PHP dependencies. Usually everything we need is bundled with WordPress, but sometimes we need external PHP libraries like "Patchwork". Composer is a great way to manage those external libraries.
 
 When a WordPress install is managed and maintained by an engineering team, and when the infrastructure supports it, plugins in a WordPress project can be easily managed using Composer. [WordPress Packagist](https://wpackagist.org/) provides a Composer repository that mirrors all public WordPress plugins and themes.


### PR DESCRIPTION
Follow up on the abandoned PR #173. Just removes Bower from the recommended Tools. We can discuss replacing it with something else at another time.

@timwright12 does this work for you?