### PR TITLE
Add missing ref to "top"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header id="page-header" role="banner">
 	<div class="page-header-content">
 		<a href="{{ site.baseurl }}" class="logo-link">10up</a>
-		<nav class="page-nav top-nav" role="navigation" aria-label="main-navigation">
+		<nav id="top" class="page-nav top-nav" role="navigation" aria-label="main-navigation">
 			<ul class="header-nav nav-dropdowns js-mobile-expandable">
 				{% assign pages_list = site.pages | sort: "weight" %}
 				{% assign group = 'navigation' %}


### PR DESCRIPTION
All section links reference an anchor which seems to be missing from the codebase: `#top`. The existing `nav` element with class `top-nav` appears to be the best candidate.