### PR TITLE
Add archiving branches as part of cleanup

### DIFF
--- a/_includes/markdown/Version-Control.md
+++ b/_includes/markdown/Version-Control.md
@@ -83,12 +83,21 @@ In the event that VIP makes a change to the repository, we'll capture the diff o
 * Merging the branch to ```staging```, using a non-fast-forward merge
 * Merging the branch back to ```master```, again using a non-fast-forward merge
 
-#### Archiving and Deleting Branches
+#### Deleting or Archiving and Deleting Branches
 
-This workflow will inevitably build up a large list of branches in the repository. To prevent a large number of unused branches living in the repository, we'll archive and delete them after feature development is complete.
+This workflow will inevitably build up a large list of branches in the repository. To prevent a large number of unused branches living in the repository, we'll delete or archive and delete them after feature development is complete.
+
+### Deleting branches
+When projects use non-ff merges to master, we can safely delte feature branches because all commits are preserved and can be located from the merge commit.
 
 * Move to another branch (doesn't matter which): eg. `git checkout master`
-* Archive the branch: `git tag archive/branch-name branch-name` 
+* Delete the branch (both on local and remote): `git branch -D branch-name; git push :branch-name`
+
+### Archiving and Deleting branches
+When projects use squash merges to create a more streamlined history in master, we should archive branches before deleting them to preserve the commit history. Branch tag archives also prove a useful history of branches, in case a specific branch is needed later.
+
+* Move to another branch (doesn't matter which): eg. `git checkout master`
+* Archive the branch: `git tag archive/branch-name branch-name`
 * Delete the branch (both on local and remote): `git branch -D branch-name; git push :branch-name`
 * Push the archive tag: `git push origin archive/branch-name`
 

--- a/_includes/markdown/Version-Control.md
+++ b/_includes/markdown/Version-Control.md
@@ -88,7 +88,7 @@ In the event that VIP makes a change to the repository, we'll capture the diff o
 This workflow will inevitably build up a large list of branches in the repository. To prevent a large number of unused branches living in the repository, we'll delete or archive and delete them after feature development is complete.
 
 ### Deleting branches
-When projects use non-ff merges to master, we can safely delte feature branches because all commits are preserved and can be located from the merge commit.
+When projects use non-ff merges to master, we can safely delete feature branches because all commits are preserved and can be located from the merge commit.
 
 * Move to another branch (doesn't matter which): eg. `git checkout master`
 * Delete the branch (both on local and remote): `git branch -D branch-name; git push :branch-name`

--- a/_includes/markdown/Version-Control.md
+++ b/_includes/markdown/Version-Control.md
@@ -83,12 +83,15 @@ In the event that VIP makes a change to the repository, we'll capture the diff o
 * Merging the branch to ```staging```, using a non-fast-forward merge
 * Merging the branch back to ```master```, again using a non-fast-forward merge
 
-#### Deleting Branches
+#### Archiving and Deleting Branches
 
-This workflow will inevitably build up a large list of branches in the repository. To prevent a large number of unused branches living in the repository, we'll delete them after feature development is complete.
+This workflow will inevitably build up a large list of branches in the repository. To prevent a large number of unused branches living in the repository, we'll archive and delete them after feature development is complete.
 
-* Move to another branch (doesn't matter which)
-* Delete the branch (both on local and remote)
+* Move to another branch (doesn't matter which): eg. `git checkout master`
+* Archive the branch: `git tag archive/branch-name branch-name` 
+* Delete the branch (both on local and remote): `git branch -D branch-name; git push :branch-name`
+* Push the archive tag: `git push origin archive/branch-name`
+
 
 ### Plugins
 


### PR DESCRIPTION
### Proposing
* Archive branches as part of cleanup flow when deleting them.
* add exact git commands to clarify what should happen

### Benefits
Keeping an archive of merged branch as tag captures makes restoring branches much easier should the need arise and simplifies some repository forensics, eg tracking down specific commits from a squashed merge.