### PR TITLE
Update Link Treatment to Match 10up.com

### DIFF
--- a/_includes/_sass/base/_base.scss
+++ b/_includes/_sass/base/_base.scss
@@ -33,30 +33,24 @@ img {
 }
 
 a {
-	color: darken($color-accent-alternate, 10%);
+	background-image: linear-gradient(transparent calc(100% - 7px), $color-error-light 0),
+	linear-gradient(transparent calc(100% - 7px), $color-accent-alternate-2 0);
+	background-position: 0 0;
+	background-repeat: no-repeat;
+	background-size: 0 100%, 100% 100%;
+	color: $color-dark;
 	text-decoration: none;
+	transition: all .1s;
 
 	&:visited {
-		color: desaturate($color-accent-alternate, 20%);
+		color: $color-dark;
 	}
 
 	&:hover,
 	&:active {
-		color: saturate( darken($color-accent-alternate, 10%), 10% );
+		background-size: 100% 100%, 100% 100%;
+		color: $color-dark;
 	}
-}
-
-p a {
-	border-bottom: 1px solid rgba( $color-accent-alternate, .3 );
-
-	&:hover {
-		border-bottom-color: rgba( saturate( darken( $color-accent-alternate, 10%), 10% ), .8 );
-	}
-
-	&:visited {
-
-	}
-
 }
 
 // otherwise it's too wonky with our static header on mobile

--- a/_includes/_sass/base/_base.scss
+++ b/_includes/_sass/base/_base.scss
@@ -46,8 +46,8 @@ a {
 		color: $color-dark;
 	}
 
-	&:hover,
-	&:active {
+	&:focus,
+	&:hover {
 		background-size: 100% 100%, 100% 100%;
 		color: $color-dark;
 	}

--- a/_includes/_sass/base/_base.scss
+++ b/_includes/_sass/base/_base.scss
@@ -69,31 +69,3 @@ body #wpadminbar {
 	display: none;
 	speak: none;
 }
-
-// .template-header {
-// 	padding-top: 4rem;
-// 	padding-bottom: 4rem;
-// 	text-align: center;
-
-// 	@include breakpoint($breakpoint-alpha) {
-// 		padding-bottom: 11.5rem;
-// 		padding-top: 14rem;
-// 	}
-
-// 	h1,
-// 	.subhead {
-// 		margin-top: 0;
-// 	}
-
-// 	*:last-child {
-// 		margin-bottom: 0;
-// 	}
-
-// 	.wp-post-image {
-// 		margin-top:3rem;
-
-// 		@include breakpoint($breakpoint-alpha) {
-// 			margin-top:8rem;
-// 		}
-// 	}
-// }

--- a/_includes/_sass/base/_base.scss
+++ b/_includes/_sass/base/_base.scss
@@ -9,27 +9,27 @@ html {
 }
 
 body {
+	background-color: $color-background-color-default;
+	color: $color-text-default;
+	font-family: $font-family-sans;
 	font-size: $base-font-size;
 	line-height: $base-line-height;
-	color: $color-text-default;
-	background-color: $color-background-color-default;
-	font-family: $font-family-sans;
-    padding-top: 60px;
+	padding-top: 60px;
 }
 
 ::selection {
 	background: $party-blue; /* Webkit */
-	color:white;
+	color: $white;
 }
-	
+
 ::-moz-selection {
 	background: $party-blue; /* Firefox */
-	color:white;
+	color: $white;
 }
 
 img {
-	max-width: 100%;
 	height: auto;
+	max-width: 100%;
 }
 
 a {
@@ -55,14 +55,14 @@ a {
 
 // otherwise it's too wonky with our static header on mobile
 body #wpadminbar {
-  position: fixed;
+	position: fixed;
 }
 
 // Reusable, toolbox kind of class
 .screen-reader-text {
+	left: -9999px;
 	position: absolute;
 	top: -9999px;
-	left: -9999px;
 }
 
 .interface-checkbox {

--- a/_includes/_sass/global/_variables.scss
+++ b/_includes/_sass/global/_variables.scss
@@ -4,6 +4,7 @@ $humming-bird: #cef8f7;
 $business-red: #b73030;
 $business-red-light: #b72f2f;
 
+$white: #fff;
 $very-light-grey: #fefefe;
 $light-grey: #F9F9F9;
 $medium-grey: #eeeeee; /*used to be "light-grey" but needed a lighter grey added*/

--- a/_includes/_sass/global/_variables.scss
+++ b/_includes/_sass/global/_variables.scss
@@ -10,6 +10,7 @@ $light-grey: #F9F9F9;
 $medium-grey: #eeeeee; /*used to be "light-grey" but needed a lighter grey added*/
 $dark-grey: #545353;
 $color-mineshaft: #303030;
+$color-mineshaft-2: #3f3f3f;
 $very-dark-grey: #232323;
 $almost-black: #111;
 

--- a/_includes/_sass/global/_variables.scss
+++ b/_includes/_sass/global/_variables.scss
@@ -1,5 +1,6 @@
 // Colors
 $party-blue: #54cdcd;
+$humming-bird: #cef8f7;
 $business-red: #b73030;
 $business-red-light: #b72f2f;
 
@@ -42,6 +43,9 @@ $color-accent-light-text: lighten($color-accent-light, 30%);
 
 $color-accent-alternate: $party-blue;
 $color-accent-alternate-text: lighten($color-accent-alternate, 30%);
+
+$color-accent-alternate-2: $humming-bird;
+$color-accent-alternate-2-text: contrast($color-accent-alternate-2);
 
 $color-button: $very-dark-grey;
 $color-button-text: contrast($color-button);

--- a/_includes/_sass/global/_variables.scss
+++ b/_includes/_sass/global/_variables.scss
@@ -8,6 +8,7 @@ $very-light-grey: #fefefe;
 $light-grey: #F9F9F9;
 $medium-grey: #eeeeee; /*used to be "light-grey" but needed a lighter grey added*/
 $dark-grey: #545353;
+$color-mineshaft: #303030;
 $very-dark-grey: #232323;
 $almost-black: #111;
 

--- a/_includes/_sass/includes/_footer-about.scss
+++ b/_includes/_sass/includes/_footer-about.scss
@@ -1,5 +1,5 @@
 .footer-about {
-	background-color: $color-mineshaft;
+	background-color: $color-mineshaft-2;
 	color: $default-light-color;
 
 	a {

--- a/_includes/_sass/includes/_footer-about.scss
+++ b/_includes/_sass/includes/_footer-about.scss
@@ -9,16 +9,16 @@
 	}
 
 	.footer-about-inner {
+		margin: 0 auto;
 		max-width: $single-max-width;
 		padding: $guaranteed-edge-standoff $guaranteed-edge-standoff $guaranteed-edge-standoff/2 $guaranteed-edge-standoff;
-		margin: 0 auto;
 	}
 
 	.cta-careers {
-		margin-bottom: $gutter-width;
 		display: inline-block;
-		width: 48%;
+		margin-bottom: $gutter-width;
 		vertical-align: top;
+		width: 48%;
 
 		.button {
 			margin-top: .5em;
@@ -28,10 +28,10 @@
 
 	.license {
 		display: inline-block;
-		width: 48%;
 		margin-left: 2%;
-		vertical-align: top;
 		text-align: right;
+		vertical-align: top;
+		width: 48%;
 
 		p {
 			font-size: 1rem;

--- a/_includes/_sass/includes/_footer-about.scss
+++ b/_includes/_sass/includes/_footer-about.scss
@@ -41,7 +41,7 @@
 		a {
 			text-decoration: underline;
 
-			&:active,
+			&:focus,
 			&:hover {
 				color: $color-accent-alternate-2;
 			}

--- a/_includes/_sass/includes/_footer-about.scss
+++ b/_includes/_sass/includes/_footer-about.scss
@@ -1,5 +1,5 @@
 .footer-about {
-	background-color: #3f3f3f;
+	background-color: $color-mineshaft;
 	color: $default-light-color;
 
 	a {

--- a/_includes/_sass/includes/_footer-about.scss
+++ b/_includes/_sass/includes/_footer-about.scss
@@ -2,6 +2,12 @@
 	background-color: #3f3f3f;
 	color: $default-light-color;
 
+	a {
+		background: none;
+		color: $default-light-color;
+		transition: none;
+	}
+
 	.footer-about-inner {
 		max-width: $single-max-width;
 		padding: $guaranteed-edge-standoff $guaranteed-edge-standoff $guaranteed-edge-standoff/2 $guaranteed-edge-standoff;
@@ -30,6 +36,15 @@
 		p {
 			font-size: 1rem;
 			margin: 1rem 0;
+		}
+
+		a {
+			text-decoration: underline;
+
+			&:active,
+			&:hover {
+				color: $color-accent-alternate-2;
+			}
 		}
 	}
 

--- a/_includes/_sass/includes/_footer.scss
+++ b/_includes/_sass/includes/_footer.scss
@@ -3,6 +3,11 @@ footer[role="contentinfo"] {
 	background-color: #303030;
 	position: relative;
 
+	a {
+		background: none;
+		transition: none;
+	}
+
 	.logo-link {
 		display: none;
 		@extend %hide-text;

--- a/_includes/_sass/includes/_footer.scss
+++ b/_includes/_sass/includes/_footer.scss
@@ -79,6 +79,7 @@ footer[role="contentinfo"] {
 			padding: 21px 0 18px;
 			position: relative;
 
+			&:focus,
 			&:hover {
 				text-decoration: none;
 

--- a/_includes/_sass/includes/_footer.scss
+++ b/_includes/_sass/includes/_footer.scss
@@ -63,6 +63,7 @@ footer[role="contentinfo"] {
 			color: lighten($color-medium-dark, 10%);
 			padding: .5em;
 
+			&:focus,
 			&:hover {
 				color: $white;
 			}

--- a/_includes/_sass/includes/_footer.scss
+++ b/_includes/_sass/includes/_footer.scss
@@ -1,6 +1,6 @@
 footer[role="contentinfo"] {
+	background-color: $color-mineshaft;
 	padding: 0 $guaranteed-edge-standoff;
-	background-color: #303030;
 	position: relative;
 
 	a {
@@ -9,28 +9,30 @@ footer[role="contentinfo"] {
 	}
 
 	.logo-link {
-		display: none;
 		@extend %hide-text;
+
+		display: none;
+
 		@include breakpoint($breakpoint-alpha) {
-			display: block;
-			position: absolute;
+			@include transition(background-size, 150ms, linear);
+
+			background: $color-mineshaft url("img/10up-icon-reversed.svg") no-repeat center;
+			background-size: 42%;
+			border-top-left-radius: 100%;
+			border-top-right-radius: 100%;
 			bottom: 0;
+			display: block;
+			height: $header-logo-small;
 			left: 50%;
 			margin-left: -$header-logo-small / 2;
-			height: $header-logo-small;
+			position: absolute;
 			width: $header-logo-small;
-			border-top-right-radius: 100%;
-			border-top-left-radius: 100%;
 			z-index: 10; /* So that it overlays any expanded .top-nav */
-			background: #303030 url("img/10up-icon-reversed.svg") no-repeat center;
-			-webkit-background-size: 42%;
-			background-size: 42%;
-			@include transition(background-size, 150ms, linear);
 		}
 		@include breakpoint($breakpoint-bravo) {
-			margin-left: -$header-logo-large / 2;
 			bottom: 0;
 			height: $header-logo-large;
+			margin-left: -$header-logo-large / 2;
 			width: $header-logo-large;
 		}
 	}
@@ -38,30 +40,31 @@ footer[role="contentinfo"] {
 	ul {
 		@extend %caps-text;
 		@include inline-list();
+
+		display: inline-block;
 		font-size: 12px;
 		font-weight: 600;
 		line-height: inherit;
-		display: inline-block;
 		margin: 0;
-		width: 49%;
 		padding-right: $header-logo-large;
 		text-align: right;
+		width: 49%;
 	}
 
 	.footer-social {
+		display: inline-block;
 		font-size: 1.7rem;
 		padding-bottom: 0;
-		display: inline-block;
+		padding-left: $header-logo-large;
 		vertical-align: middle;
 		width: 49%;
-		padding-left: $header-logo-large;
 
 		a {
 			color: lighten($color-medium-dark, 10%);
 			padding: .5em;
 
 			&:hover {
-				color: #fff;
+				color: $white;
 			}
 		}
 	}
@@ -70,36 +73,38 @@ footer[role="contentinfo"] {
 		margin: 0 0.5em;
 
 		a {
-			display: inline-block;
 			color: $color-dark-text;
+			display: inline-block;
 			padding: 21px 0 18px;
-			// border-bottom: 3px solid transparent;
-
 			position: relative;
 
 			&:hover {
 				text-decoration: none;
-				// border-bottom-color: $color-dark-text;
+
 				&:after {
-					bottom: 7px;
 					@include opacity(1);
+
+					bottom: 7px;
 				}
 			}
 			@include breakpoint($breakpoint-alpha) {
+
 				&:after {
-					content: "";
-					width: 100%;
-					height: 5px;
-					background: $color-dark-text;
-					position: absolute;
-					bottom: 5px;
-					left: 0;
+					@include opacity(0);
+					@include transition(all, 80ms, ease-in);
+
 					-webkit-backface-visibility: hidden;
 					-moz-backface-visibility: hidden;
 					-ms-backface-visibility: hidden;
+
 					backface-visibility: hidden;
-					@include opacity(0);
-					@include transition(all, 80ms, ease-in);
+					background: $color-dark-text;
+					bottom: 5px;
+					content: "";
+					height: 5px;
+					left: 0;
+					position: absolute;
+					width: 100%;
 				}
 			}
 		}

--- a/_includes/_sass/includes/_header.scss
+++ b/_includes/_sass/includes/_header.scss
@@ -118,6 +118,7 @@
 		display: none;
 	}
 
+	&:focus,
 	&:hover {
 		color: $color-accent-alternate-2;
 	}
@@ -137,6 +138,7 @@
 		right: 0;
 	}
 
+	&:focus,
 	&:hover {
 		color: $color-accent-alternate-2;
 	}
@@ -224,6 +226,7 @@
 			padding: 21px 0;
 			position: relative;
 
+			&:focus,
 			&:hover {
 				text-decoration: none;
 

--- a/_includes/_sass/includes/_header.scss
+++ b/_includes/_sass/includes/_header.scss
@@ -2,9 +2,9 @@
 	background-color: $color-mineshaft;
 	padding: 0 $guaranteed-edge-standoff;
 	position: fixed;
-	z-index: 9999;
-	width: 100%;
 	top: 0;
+	width: 100%;
+	z-index: 9999;
 
 	body.admin-bar & {
 		top: 46px;
@@ -13,37 +13,38 @@
 			top: 32px;
 		}
 	}
+
 	.logo-link {
-		position: absolute;
+		@extend %hide-text;
+
+		background: $color-mineshaft url("img/10up-logo-full.svg") no-repeat 46% 30%;
+		background-size: 50%;
+		border-radius: 100%;
 		bottom: -$header-logo-small-protrusion;
+		height: $header-logo-small;
 		left: 50%;
 		margin-left: -$header-logo-small / 2;
-		height: $header-logo-small;
+		position: absolute;
 		width: $header-logo-small;
-		border-radius: 100%;
 		z-index: 10; /* So that it overlays any expanded .top-nav */
-		@extend %hide-text;
-		background: #303030 url("img/10up-logo-full.svg") no-repeat 46% 30%;
-		-webkit-background-size: 50%;
-		background-size: 50%;
+
 		@include breakpoint($breakpoint-bravo) {
-			margin-left: -$header-logo-large / 2;
+			background-position: 46% 50%;
+			background-size: 45%;
 			bottom: -$header-logo-large-protrusion;
 			height: $header-logo-large;
+			margin-left: -$header-logo-large / 2;
 			width: $header-logo-large;
-			-webkit-background-size: 45%;
-			background-size: 45%;
-			background-position: 46% 50%;
 		}
 	}
 
 	.top-nav {
+		background-color: $color-mineshaft;
+		height: 0;
+		padding: 0;
+		position: relative;
 		top: 6rem;
 		z-index: 5; /* higher than normal so it overlays content elements */
-		background-color: #303030;
-		padding: 0;
-		height: 0;
-		position: relative;
 
 		.js-mobile-expandable {
 			display: none;
@@ -52,9 +53,9 @@
 				display: block;
 
 				&:before {
-					content: '';
 					border: 10px solid transparent;
-					border-bottom-color: #222;
+					border-bottom-color: $very-dark-grey;
+					content: '';
 					display: block;
 					position: absolute;
 					right: .25em;
@@ -64,14 +65,14 @@
 		}
 
 		.header-nav {
-			background-color: #222;
+			background-color: $very-dark-grey;
 			text-align: right;
 
 			@include breakpoint($breakpoint-bravo) {
 				background-color: transparent;
-				text-align: center;
 				display: block;
 				padding-left: 6px;
+				text-align: center;
 
 				li:nth-child(6) {
 					margin-right: 82px;
@@ -87,9 +88,9 @@
 		@include transition(height, 150ms, linear);
 
 		@include breakpoint($breakpoint-bravo) {
+			background-color: transparent;
 			display: inline-block;
 			height: auto !important;
-			background-color: transparent;
 			position: relative;
 			top: auto;
 			width: 100%;
@@ -98,9 +99,8 @@
 }
 
 .page-header-content {
-	// @extend %grid-context;
-	position: relative;
 	height: 6rem;
+	position: relative;
 }
 
 // handles layout and functionality for the header menus.
@@ -108,10 +108,11 @@
 .toggle-menu-icon {
 	@extend %menu-icon;
 	@include icon('menu');
+
+	background-color: $almost-black;
+	background-image: none;
 	display: block;
 	font-size: 1.3rem;
-	background-color: black;
-	background-image: none;
 
 	@include breakpoint($breakpoint-bravo) {
 		display: none;
@@ -125,10 +126,11 @@
 .main-nav-supplemental-icon {
 	@extend %menu-icon;
 	@include icon('github');
+
+	background-color: $almost-black;
+	background-image: none;
 	display: block;
 	font-size: 1.3rem;
-	background-color: black;
-	background-image: none;
 	right: 2.5em;
 
 	@include breakpoint($breakpoint-bravo) {
@@ -142,14 +144,15 @@
 
 .header-nav {
 	@extend %caps-text;
+
 	color: $color-dark-text;
 	line-height: inherit;
 	margin: 0;
-	padding: 0;
-	padding-top: 1em;
+	padding: 1em 0 0;
 
 	@include breakpoint($breakpoint-bravo) {
 		@include inline-list();
+
 		display: block !important;
 		padding-top: 0;
 	}
@@ -163,35 +166,37 @@
 		list-style-type: none;
 		padding: .5em 1em;
 
-			&:hover {
-				background-color: #303030;
-				@include breakpoint($breakpoint-bravo) {
-					background-color: transparent;
-				}
-			}
-
-
 		@include breakpoint($breakpoint-bravo) {
-			padding: 0;
 			margin: 0 0.3em;
+			padding: 0;
 
 			@include breakpoint($breakpoint-charlie) {
 				margin: 0 0.4em;
 			}
 		}
 
+		&:hover {
+			background-color: $color-mineshaft;
+
+			@include breakpoint($breakpoint-bravo) {
+				background-color: transparent;
+			}
+		}
+
 		&.current-menu-item > a,
 		&.current_page_parent > a {
+
 			&:after {
-				background-color: #585858;
-				bottom: 7px;
 				@include opacity(1);
+
+				background-color: $dary-grey;
+				bottom: 7px;
 			}
 
 			body.home &:after {
-				bottom: 7px;
 				@include opacity(0);
-				// border-top-color: transparent;
+
+				bottom: 7px;
 			}
 		}
 	}
@@ -205,40 +210,45 @@
 }
 
 .page-header-content {
+
 	li a,
 	h1 a {
+		color: $color-dark-text;
 		display: block;
-		padding: .8rem 0;
 		font-size: 14px;
 		font-weight: 400;
-		color: $color-dark-text;
+		padding: .8rem 0;
 
 		@include breakpoint($breakpoint-bravo) {
-			padding: 21px 0;
 			font-size: 11px;
+			padding: 21px 0;
 			position: relative;
 
 			&:hover {
 				text-decoration: none;
+
 				&:after {
-					bottom: 7px;
 					@include opacity(1);
+
+					bottom: 7px;
 				}
 			}
 			&:after {
-				content: "";
-				width: 100%;
-				height: 5px;
-				background: $color-dark-text;
-				position: absolute;
-				bottom: 5px;
-				left: 0;
+				@include opacity(0);
+				@include transition(all, 80ms, ease-in);
+
 				-webkit-backface-visibility: hidden;
 				-moz-backface-visibility: hidden;
 				-ms-backface-visibility: hidden;
+
 				backface-visibility: hidden;
-				@include opacity(0);
-				@include transition(all, 80ms, ease-in);
+				background: $color-dark-text;
+				bottom: 5px;
+				content: "";
+				height: 5px;
+				left: 0;
+				position: absolute;
+				width: 100%;
 			}
 
 			@include breakpoint($breakpoint-charlie) {

--- a/_includes/_sass/includes/_header.scss
+++ b/_includes/_sass/includes/_header.scss
@@ -138,6 +138,10 @@
 		right: 0;
 	}
 
+	&:visited {
+		color: $white;
+	}
+
 	&:focus,
 	&:hover {
 		color: $color-accent-alternate-2;
@@ -236,6 +240,7 @@
 					bottom: 7px;
 				}
 			}
+
 			&:after {
 				@include opacity(0);
 				@include transition(all, 80ms, ease-in);

--- a/_includes/_sass/includes/_header.scss
+++ b/_includes/_sass/includes/_header.scss
@@ -189,7 +189,7 @@
 			&:after {
 				@include opacity(1);
 
-				background-color: $dary-grey;
+				background-color: $dark-grey;
 				bottom: 7px;
 			}
 

--- a/_includes/_sass/includes/_header.scss
+++ b/_includes/_sass/includes/_header.scss
@@ -111,9 +111,14 @@
 	display: block;
 	font-size: 1.3rem;
 	background-color: black;
+	background-image: none;
 
 	@include breakpoint($breakpoint-bravo) {
 		display: none;
+	}
+
+	&:hover {
+		color: $color-accent-alternate-2;
 	}
 }
 
@@ -123,10 +128,15 @@
 	display: block;
 	font-size: 1.3rem;
 	background-color: black;
+	background-image: none;
 	right: 2.5em;
 
 	@include breakpoint($breakpoint-bravo) {
 		right: 0;
+	}
+
+	&:hover {
+		color: $color-accent-alternate-2;
 	}
 }
 
@@ -142,6 +152,11 @@
 		@include inline-list();
 		display: block !important;
 		padding-top: 0;
+	}
+
+	a {
+		background: none;
+		transition: none;
 	}
 
 	li {

--- a/_includes/_sass/includes/_header.scss
+++ b/_includes/_sass/includes/_header.scss
@@ -1,6 +1,6 @@
 #page-header {
+	background-color: $color-mineshaft;
 	padding: 0 $guaranteed-edge-standoff;
-	background: #303030;
 	position: fixed;
 	z-index: 9999;
 	width: 100%;

--- a/_includes/_sass/includes/_table-of-contents.scss
+++ b/_includes/_sass/includes/_table-of-contents.scss
@@ -79,6 +79,7 @@
 		text-decoration: none;
 	}
 
+	a:focus,
 	a:hover {
 		text-decoration: underline;
 	}

--- a/_includes/_sass/includes/_table-of-contents.scss
+++ b/_includes/_sass/includes/_table-of-contents.scss
@@ -74,13 +74,14 @@
 	}
 
 	a {
+		background-image: none;
+		color: $almost-black;
 		display: inline-block;
-		padding-bottom: 1px;
+		text-decoration: none;
 	}
 
 	a:hover {
-		padding-bottom: 0;
-		border-bottom: 1px solid rgba(saturate(darken($color-accent-alternate, 10%), 10%), .8);
+	text-decoration: underline;
 	}
 
 	h3 {

--- a/_includes/_sass/includes/_table-of-contents.scss
+++ b/_includes/_sass/includes/_table-of-contents.scss
@@ -3,34 +3,34 @@
 	padding: $guaranteed-edge-standoff $guaranteed-edge-standoff;
 
 	&:after {
+		clear: both;
 		content: '';
 		display: block;
-		clear: both;
 	}
 
 	.col {
-		word-break: break-word;
 		border-top: 1px solid darken(#efefef, 5%);
 		margin: 0;
+		word-break: break-word;
 
 		&:first-child {
 			border-top: none;
 		}
 
 		@include breakpoint($breakpoint-bravo) {
-			width: 50%;
-			float: left;
-			vertical-align: top;
 			border-right: 1px solid darken(#efefef, 5%);
+			float: left;
 			padding-right: 2%;
+			vertical-align: top;
+			width: 50%;
 
 			&:nth-child(2n+1) {
-				margin-right: 0;
-				border-left: 1px solid darken( #efefef, 5%);
+				border-left: 1px solid darken(#efefef, 5%);
 				border-right: none;
+				left: -1px; /* middle border overlap */
+				margin-right: 0;
 				padding-left: 2%;
 				position: relative;
-				left: -1px; /* middle border overlap */
 			}
 
 			&:nth-of-type(2n+3){
@@ -39,8 +39,8 @@
 		}
 
 		@include breakpoint($breakpoint-charlie) {
-			width: 24%;
 			border-right: none;
+			width: 24%;
 
 			/** reset from breakpoint-alpha **/
 			&:nth-of-type(2n+3) {
@@ -64,13 +64,12 @@
 	}
 
 	h2 {
-		margin: 0;
-		margin-bottom: 1em;
+		margin: 0 0 1em;
 	}
 
 	ul {
-		padding-left: 0;
 		margin-top: .5em;
+		padding-left: 0;
 	}
 
 	a {
@@ -81,14 +80,15 @@
 	}
 
 	a:hover {
-	text-decoration: underline;
+		text-decoration: underline;
 	}
 
 	h3 {
 		@extend %caps-text;
-		margin-bottom: 0;
+
 		font-size: 1.2em;
 		font-weight: 600;
+		margin-bottom: 0;
 	}
 
 	li {


### PR DESCRIPTION
Addresses and fixes #266 

I targeted the links in the main content area to match the treatment currently seen on https://10up.com/blog/

I also did some clean up (alpha sorting, replace static hex colors with variables) in the `_header.scss` and `_footer.scss` partials.

I also made sure the header and footer links were not affected by the new styles.

Attaching a Gif of resulting treatment

![10upengineering-link-treatment](https://user-images.githubusercontent.com/405912/51201753-e242cd80-18ca-11e9-9229-e689db3c7e91.gif)
