### PR TITLE
add SVG link under Markup section on home page

### DIFF
--- a/index.md
+++ b/index.md
@@ -40,6 +40,7 @@ updated: 6 Oct 2014
 			<li><a href="{{ site.baseurl }}/markup/#classes-ids">Classes and ID's</a></li>
 			<li><a href="{{ site.baseurl }}/markup/#accessibility">Accessibility</a></li>
 			<li><a href="{{ site.baseurl }}/markup/#progressive-enhancement">Progressive Enhancement</a></li>
+			<li><a href="{{ site.baseurl }}/markup/#svg">SVG</a></li>
 		</ul>
 	</div>
 


### PR DESCRIPTION
Fixes #290 

__Before ("SVG" link missing):__
![screenshot 2019-03-01 11 47 18](https://user-images.githubusercontent.com/405912/53662804-dff5c200-3c31-11e9-975a-4a135a8a8cd2.png)

__After ("SVG" link added):
![screenshot 2019-03-01 14 53 39](https://user-images.githubusercontent.com/405912/53662832-f3a12880-3c31-11e9-9118-d201454f8565.png)
