### PR TITLE
fix: Update broken intro page design menu URL's

### DIFF
--- a/index.md
+++ b/index.md
@@ -105,13 +105,12 @@ updated: 6 Oct 2014
 	</div>
 
 	<div class="col">
-		<h3><a href="{{ site.baseurl }}/design/#top">Project Design</a></h3>
+		<h3><a href="{{ site.baseurl }}/structure/#top">Project Design</a></h3>
 		<ul>
-			<li><a href="{{ site.baseurl }}/design/#file-organization">File Organization</a></li>
-			<li><a href="{{ site.baseurl }}/design/#dependencies">Dependencies</a></li>
-			<li><a href="{{ site.baseurl }}/design/#integrations">Third-Party Integrations</a></li>
-			<li><a href="{{ site.baseurl }}/design/#modular-code">Modular Code</a></li>
-			<li><a href="{{ site.baseurl }}/design/#privacy">Privacy</a></li>
+			<li><a href="{{ site.baseurl }}/structure/#file-organization">File Organization</a></li>
+			<li><a href="{{ site.baseurl }}/structure/#dependencies">Dependencies</a></li>
+			<li><a href="{{ site.baseurl }}/structure/#integrations">Third-Party Integrations</a></li>
+			<li><a href="{{ site.baseurl }}/structure/#modular-code">Modular Code</a></li>
 		</ul>
 	</div>
 

--- a/structure.md
+++ b/structure.md
@@ -14,8 +14,6 @@ subnav:
     tag: integrations
   - title: Modular Code
     tag: modular-code
-  - title: Privacy
-    tag: privacy
 updated: 23 June 2015
 ---
 


### PR DESCRIPTION
Thought it would be good to write a couple lines of code on my first week ;)

It appears the design page was renamed to structure at some point. The top menu looks like it generates links dynamically but these are hardcoded. The #privacy section also seems to not exist so part of updating these was removing that link.

Edit: You can find the broken links under the "Project Design" section on the [home page](https://10up.github.io/Engineering-Best-Practices/).