### PR TITLE
Remove Codex References in PHP Section

### DIFF
--- a/_includes/markdown/PHP.md
+++ b/_includes/markdown/PHP.md
@@ -4,7 +4,7 @@ Writing performant code is absolutely critical, especially at the enterprise lev
 
 ### Efficient Database Queries
 
-When querying the database in WordPress, you should generally use a [```WP_Query```](https://codex.wordpress.org/Class_Reference/WP_Query) object. ```WP_Query``` objects take a number of useful arguments and do things behind-the-scenes that other database access methods such as [```get_posts()```](https://developer.wordpress.org/reference/functions/get_posts/) do not.
+When querying the database in WordPress, you should generally use a [```WP_Query```](https://developer.wordpress.org/reference/functions/query_posts/) object. ```WP_Query``` objects take a number of useful arguments and do things behind-the-scenes that other database access methods such as [```get_posts()```](https://developer.wordpress.org/reference/functions/get_posts/) do not.
 
 Here are a few key points:
 
@@ -86,9 +86,9 @@ Here are a few key points:
 
     See [WordPress VIP](https://vip.wordpress.com/documentation/performance-improvements-by-removing-usage-of-post__not_in/).
 
-* A [taxonomy](https://codex.wordpress.org/Taxonomies) is a tool that lets us group or classify posts.
+* A [taxonomy](https://wordpress.org/support/article/taxonomies/) is a tool that lets us group or classify posts.
 
-    [Post meta](https://codex.wordpress.org/Custom_Fields) lets us store unique information about specific posts. As such the way post meta is stored does not facilitate efficient post lookups. Generally, looking up posts by post meta should be avoided (sometimes it can't). If you have to use one, make sure that it's not the main query and that it's cached.
+    [Post meta](https://wordpress.org/support/article/custom-fields/) lets us store unique information about specific posts. As such the way post meta is stored does not facilitate efficient post lookups. Generally, looking up posts by post meta should be avoided (sometimes it can't). If you have to use one, make sure that it's not the main query and that it's cached.
 
 * Passing ```cache_results => false``` to ```WP_Query``` is usually not a good idea.
 
@@ -123,7 +123,7 @@ As outlined above, `get_posts()` and `WP_Query`, apart from some slight nuances,
 * It creates a new `WP_Query` object with the parameters you specify.
 * It replaces the existing main query loop with a new instance of `WP_Query`.
 
-As noted in the [WordPress Codex (along with a useful query flow chart)](https://codex.wordpress.org/Function_Reference/query_posts), `query_posts()` isn't meant to be used by plugins or themes. Due to replacing and possibly re-running the main query, `query_posts()` is not performant and certainly not an acceptable way of changing the main query.
+As noted in the [WordPress Docs (along with a useful query flow chart)](https://developer.wordpress.org/reference/functions/query_posts/#more-information), `query_posts()` isn't meant to be used by plugins or themes. Due to replacing and possibly re-running the main query, `query_posts()` is not performant and certainly not an acceptable way of changing the main query.
 
 #### Build arrays that encourage lookup by key instead of search by value
 
@@ -157,7 +157,7 @@ Caching is simply the act of storing computed data somewhere for later use, and 
 
 Object caching is the act of caching data or objects for later use. In the context of WordPress, objects are cached in memory so they can be retrieved quickly.
 
-In WordPress, the object cache functionality provided by [```WP_Object_Cache```](https://developer.wordpress.org/reference/classes/wp_object_cache/), and the [Transients API](https://codex.wordpress.org/Transients_API) are great solutions for improving performance on long-running queries, complex functions, or similar.
+In WordPress, the object cache functionality provided by [```WP_Object_Cache```](https://developer.wordpress.org/reference/classes/wp_object_cache/), and the [Transients API](https://developer.wordpress.org/apis/handbook/transients/) are great solutions for improving performance on long-running queries, complex functions, or similar.
 
 On a regular WordPress install, the difference between transients and the object cache is that transients are persistent and would write to the options table, while the object cache only persists for the particular page load.
 
@@ -279,9 +279,9 @@ There are other popular page caching solutions such as the W3 Total Cache plugin
 
 AJAX stands for Asynchronous JavaScript and XML. Often, we use JavaScript on the client-side to ping endpoints for things like infinite scroll.
 
-WordPress [provides an API](https://codex.wordpress.org/AJAX_in_Plugins) to register AJAX endpoints on ```wp-admin/admin-ajax.php```. However, WordPress does not cache queries within the administration panel for obvious reasons. Therefore, if you send requests to an admin-ajax.php endpoint, you are bootstrapping WordPress and running un-cached queries. Used properly, this is totally fine. However, this can take down a website if used on the frontend.
+WordPress [provides an API](https://developer.wordpress.org/plugins/javascript/ajax/) to register AJAX endpoints on ```wp-admin/admin-ajax.php```. However, WordPress does not cache queries within the administration panel for obvious reasons. Therefore, if you send requests to an admin-ajax.php endpoint, you are bootstrapping WordPress and running un-cached queries. Used properly, this is totally fine. However, this can take down a website if used on the frontend.
 
-For this reason, front-facing endpoints should be written by using the [Rewrite Rules API](http://codex.wordpress.org/Rewrite_API) and hooking early into the WordPress request process.
+For this reason, front-facing endpoints should be written by using the [Rewrite Rules API](https://developer.wordpress.org/apis/handbook/rewrite/) and hooking early into the WordPress request process.
 
 Here is a simple example of how to structure your endpoints:
 
@@ -352,18 +352,18 @@ We can store data using options, post meta, post types, object cache, and taxono
 
 There are a number of performance considerations for each WordPress storage vehicle:
 
-* [Options](https://codex.wordpress.org/Options_API) - The options API is a simple key-value storage system backed by a MySQL table. This API is meant to store things like settings and not variable amounts of data.
+* [Options](https://developer.wordpress.org/apis/handbook/options/) - The options API is a simple key-value storage system backed by a MySQL table. This API is meant to store things like settings and not variable amounts of data.
 
   Site performance, especially on large websites, can be negatively affected by a large options table. It's recommended to regularly monitor and keep this table under 500 rows. The "autoload" field should only be set to 'yes' for values that need to be loaded into memory on each page load.
 
   Caching plugins can also be negatively affected by a large wp_options table. Popular caching plugins such as [Memcached](https://wordpress.org/plugins/memcached/) place a 1MB limit on individual values stored in cache. A large options table can easily exceed this limit, severely slowing each page load.
 
-* [Post Meta or Custom Fields](https://codex.wordpress.org/Custom_Fields) - Post meta is an API meant for storing information specific to a post. For example, if we had a custom post type, "Product", "serial number" would be information appropriate for post meta. Because of this, it usually doesn't make sense to search for groups of posts based on post meta.
-* [Taxonomies and Terms](https://codex.wordpress.org/Taxonomies) - Taxonomies are essentially groupings. If we have a classification that spans multiple posts, it is a good fit for a taxonomy term. For example, if we had a custom post type, "Car", "Nissan" would be a good term since multiple cars are made by Nissan. Taxonomy terms can be efficiently searched across as opposed to post meta.
-* [Custom Post Types](https://codex.wordpress.org/Post_Types) - WordPress has the notion of "post types". "Post" is a post type which can be confusing. We can register custom post types to store all sorts of interesting pieces of data. If we have a variable amount of data to store such as a product, a custom post type might be a good fit.
-* [Object Cache](https://codex.wordpress.org/Class_Reference/WP_Object_Cache) - See the "[Caching](#caching)" section.
+* [Post Meta or Custom Fields](https://wordpress.org/support/article/custom-fields/) - Post meta is an API meant for storing information specific to a post. For example, if we had a custom post type, "Product", "serial number" would be information appropriate for post meta. Because of this, it usually doesn't make sense to search for groups of posts based on post meta.
+* [Taxonomies and Terms](https://wordpress.org/support/article/taxonomies/) - Taxonomies are essentially groupings. If we have a classification that spans multiple posts, it is a good fit for a taxonomy term. For example, if we had a custom post type, "Car", "Nissan" would be a good term since multiple cars are made by Nissan. Taxonomy terms can be efficiently searched across as opposed to post meta.
+* [Custom Post Types](https://wordpress.org/support/article/post-types/) - WordPress has the notion of "post types". "Post" is a post type which can be confusing. We can register custom post types to store all sorts of interesting pieces of data. If we have a variable amount of data to store such as a product, a custom post type might be a good fit.
+* [Object Cache](https://developer.wordpress.org/reference/classes/wp_object_cache/) - See the "[Caching](#caching)" section.
 
-While it is possible to use WordPress' [Filesystem API](https://codex.wordpress.org/Filesystem_API) to interact with a huge variety of storage endpoints, using the filesystem to store and deliver data outside of regular asset uploads should be avoided as this methods conflict with most modern / secure hosting solutions.
+While it is possible to use WordPress' [Filesystem API](https://developer.wordpress.org/apis/handbook/filesystem/) to interact with a huge variety of storage endpoints, using the filesystem to store and deliver data outside of regular asset uploads should be avoided as this methods conflict with most modern / secure hosting solutions.
 
 ### Database Writes
 
@@ -375,7 +375,7 @@ Writing information to the database is at the core of any website you build. Her
 
 * Store information in the correct place. See the "[Appropriate Data Storage](#appropriate-data-storage)" section.
 
-* Certain options are "autoloaded" or put into the object cache on each page load. When [creating or updating options](https://codex.wordpress.org/Options_API), you can pass an ```$autoload``` argument to [```add_option()```](https://developer.wordpress.org/reference/functions/add_option/). If your option is not going to get used often, it shouldn't be autoloaded. As of WordPress 4.2, [```update_option()```](https://developer.wordpress.org/reference/functions/update_option/) supports configuring autoloading directly by passing an optional ```$autoload``` argument. Using this third parameter is preferable to using a combination of [```delete_option()```](https://developer.wordpress.org/reference/functions/delete_option/) and ```add_option()``` to disable autoloading for existing options.
+* Certain options are "autoloaded" or put into the object cache on each page load. When [creating or updating options](https://developer.wordpress.org/apis/handbook/options/), you can pass an ```$autoload``` argument to [```add_option()```](https://developer.wordpress.org/reference/functions/add_option/). If your option is not going to get used often, it shouldn't be autoloaded. As of WordPress 4.2, [```update_option()```](https://developer.wordpress.org/reference/functions/update_option/) supports configuring autoloading directly by passing an optional ```$autoload``` argument. Using this third parameter is preferable to using a combination of [```delete_option()```](https://developer.wordpress.org/reference/functions/delete_option/) and ```add_option()``` to disable autoloading for existing options.
 
 <h2 id="design-patterns" class="anchor-heading">Design Patterns {% include Util/link_anchor anchor="design-patterns" %} {% include Util/top %}</h2>
 
@@ -506,7 +506,7 @@ in a Theme. Disabling the plugin should not result in any errors in the
 Theme code. Similarly switching the Theme should not result in any
 errors in the Plugin code.
 
-The best way to implement this is with the use of [add_theme_support](https://developer.wordpress.org/reference/functions/add_theme_support/) and [current_theme_supports](https://codex.wordpress.org/Function_Reference/current_theme_supports).
+The best way to implement this is with the use of [add_theme_support](https://developer.wordpress.org/reference/functions/add_theme_support/) and [current_theme_supports](https://developer.wordpress.org/reference/functions/current_theme_supports/).
 
 Consider a plugin that adds a custom javascript file to the `page` post
 type. The Theme should register support for this feature using
@@ -519,7 +519,7 @@ add_theme_support( 'custom-js-feature' );
 
 And the plugin should check that the current theme has indicated support
 for this feature before adding the script to the page, using
-[current_theme_supports](https://codex.wordpress.org/Function_Reference/current_theme_supports),
+[current_theme_supports](https://developer.wordpress.org/reference/functions/current_theme_supports/),
 
 ```php
 <?php
@@ -552,7 +552,7 @@ To validate is to ensure the data you've requested of the user matches what they
 
 Validation is always preferred to sanitization. Any non-static data that is stored in the database must be validated or sanitized. Not doing so can result in creating potential security vulnerabilities.
 
-WordPress has a number of [validation and sanitization functions built-in](https://codex.wordpress.org/Validating_Sanitizing_and_Escaping_User_Data#Validating:_Checking_User_Input).
+WordPress has a number of [validation](https://developer.wordpress.org/plugins/security/data-validation/#core-wordpress-functions) and [sanitization](https://developer.wordpress.org/themes/theme-security/data-sanitization-escaping/#sanitization-securing-input) functions built-in.
 
 Sometimes it can be confusing as to which is the most appropriate for a given situation. Other times, it's even appropriate to write our own sanitization and validation methods.
 
@@ -584,7 +584,7 @@ Since ```update_option()``` is storing in the database, the value must be saniti
 
 #### Raw SQL Preparation and Sanitization
 
-There are times when dealing directly with SQL can't be avoided. WordPress provides us with [```$wpdb```](https://codex.wordpress.org/Class_Reference/wpdb).
+There are times when dealing directly with SQL can't be avoided. WordPress provides us with [```$wpdb```](https://developer.wordpress.org/reference/classes/wpdb/).
 
 Special care must be taken to ensure queries are properly prepared and sanitized:
 
@@ -692,7 +692,7 @@ Here's an example:
 
 Instead of using the generic [```__()```](https://developer.wordpress.org/reference/functions/__/) function, something like [```esc_html__()```](https://developer.wordpress.org/reference/functions/esc_html__/) might be more appropriate. Instead of using the generic [```_e()```](https://developer.wordpress.org/reference/functions/_e/) function, [```esc_html_e()```](https://developer.wordpress.org/reference/functions/esc_html_e/) would instead be used.
 
-There are many escaping situations not covered in this section. Everyone should explore the [WordPress codex article](https://codex.wordpress.org/Validating_Sanitizing_and_Escaping_User_Data#Escaping:_Securing_Output) on escaping output to learn more.
+There are many escaping situations not covered in this section. Everyone should explore the [WordPress Plugin Handbook section](https://developer.wordpress.org/plugins/security/securing-output/) on escaping output to learn more.
 
 ### Nonces
 
@@ -700,7 +700,7 @@ In programming, a nonce, or number used only once, is a tool used to prevent [CS
 
 The purpose of a nonce is to make each request unique so an action cannot be replayed.
 
-WordPress' [implementation](https://codex.wordpress.org/WordPress_Nonces) of nonces are not strictly numbers used once, though they serve an equal purpose.
+WordPress' [implementation](https://developer.wordpress.org/plugins/security/nonces/) of nonces are not strictly numbers used once, though they serve an equal purpose.
 
 The literal WordPress definition of nonces is "A cryptographic token tied to a specific action, user, and window of time.". This means that while the number is not a true nonce, the resulting number *is* specifically tied to the action, user, and window of time for which it was generated.
 
@@ -738,7 +738,7 @@ if ( ! empty( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'my_a
 
 All text strings in a project should be internationalized using core localization functions. Even if the project does not currently dictate a need for translatable strings, this practice ensures translation-readiness should a future need arise.
 
-WordPress provides a myriad of [localization functionality](https://codex.wordpress.org/I18n_for_WordPress_Developers). Engineers should familiarize themselves with features such as [pluralization](https://codex.wordpress.org/I18n_for_WordPress_Developers#Plurals) and [disambiguation](https://codex.wordpress.org/I18n_for_WordPress_Developers#Disambiguation_by_context) so translations are flexible and translators have the information they need to work accurately.
+WordPress provides a myriad of [localization functionality](https://developer.wordpress.org/plugins/internationalization/). Engineers should familiarize themselves with features such as [pluralization](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#plurals) and [disambiguation](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#disambiguation-by-context) so translations are flexible and translators have the information they need to work accurately.
 
 Samuel Wood (Otto) put together a guide to WordPress internationalization best practices, and engineers should take time to familiarize themselves with its guidance: [Internationalization: You’re probably doing it wrong](http://ottopress.com/2012/internationalization-youre-probably-doing-it-wrong/)
 
@@ -790,14 +790,14 @@ Most of WordPress's translation functions don't escape output by default. So, it
 To make this easier, the WordPress API includes functions that translate and escape in a single step. Engineers are encouraged to use these functions to simplify their code:
 
 **For use in HTML**
-1. [esc_html__](https://codex.wordpress.org/Function_Reference/esc_html_2): Returns a translated and escaped string
-1. [esc_html_e](https://codex.wordpress.org/Function_Reference/esc_html_e): Echoes a translated and escaped string
-1. [esc_html_x](https://codex.wordpress.org/Function_Reference/esc_html_x): Returns a translated and escaped string, *passing a context* to the translation function
+1. [esc_html__](https://developer.wordpress.org/reference/functions/esc_html__/): Returns a translated and escaped string
+1. [esc_html_e](https://developer.wordpress.org/reference/functions/esc_html_e/): Echoes a translated and escaped string
+1. [esc_html_x](https://developer.wordpress.org/reference/functions/esc_html_x/): Returns a translated and escaped string, *passing a context* to the translation function
 
 **For use in attributes**
-1. [esc_attr__](https://codex.wordpress.org/Function_Reference/esc_attr_2): Returns a translated and escaped string
-1. [esc_attr_e](https://codex.wordpress.org/Function_Reference/esc_attr_e): Echoes a translated and escaped string
-1. [esc_attr_x](https://codex.wordpress.org/Function_Reference/esc_attr_x): Returns a translated and escaped string, *passing a context* to the translation function
+1. [esc_attr__](https://developer.wordpress.org/reference/functions/esc_attr__/): Returns a translated and escaped string
+1. [esc_attr_e](https://developer.wordpress.org/reference/functions/esc_attr_e/): Echoes a translated and escaped string
+1. [esc_attr_x](https://developer.wordpress.org/reference/functions/esc_attr_x/): Returns a translated and escaped string, *passing a context* to the translation function
 
 <h2 id="code-style" class="anchor-heading">Code Style & Documentation {% include Util/link_anchor anchor="code-style" %} {% include Util/top %}</h2>
 
@@ -905,7 +905,7 @@ $my_class_name .= 'something naughty';
 echo '<div class="test ' . esc_attr( $my_class_name ) . '">test</div>';
 ```
 
-Even better, [use WordPress' ```get_template_part()``` function as a basic template engine](http://codex.wordpress.org/Function_Reference/get_template_part#Passing_Variables_to_Template). Make your template file consist mostly of HTML, with ```<?php ?>``` tags just where you need to escape and output. The resulting file will be as readable as a heredoc/nowdoc block, but can still perform late escaping within the template itself.
+Even better, [use WordPress' ```get_template_part()``` function as a basic template engine](https://developer.wordpress.org/reference/functions/get_template_part/#comment-2349). Make your template file consist mostly of HTML, with ```<?php ?>``` tags just where you need to escape and output. The resulting file will be as readable as a heredoc/nowdoc block, but can still perform late escaping within the template itself.
 
 ### Avoid Sessions
 

--- a/_includes/markdown/PHP.md
+++ b/_includes/markdown/PHP.md
@@ -4,7 +4,7 @@ Writing performant code is absolutely critical, especially at the enterprise lev
 
 ### Efficient Database Queries
 
-When querying the database in WordPress, you should generally use a [```WP_Query```](https://developer.wordpress.org/reference/functions/query_posts/) object. ```WP_Query``` objects take a number of useful arguments and do things behind-the-scenes that other database access methods such as [```get_posts()```](https://developer.wordpress.org/reference/functions/get_posts/) do not.
+When querying the database in WordPress, you should generally use a [```WP_Query```](https://developer.wordpress.org/reference/classes/wp_query/) object. ```WP_Query``` objects take a number of useful arguments and do things behind-the-scenes that other database access methods such as [```get_posts()```](https://developer.wordpress.org/reference/functions/get_posts/) do not.
 
 Here are a few key points:
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

As WordPress Codex is being [discontinued in favor of DevHub and HelpHub](https://make.wordpress.org/docs/handbook/get-involved/current-docs-projects/#codex-migration), we should remove all references to Codex.

### Alternate Designs

Some docs are present on both plugins and theme handbooks. This PR used the plugin links.

### Benefits

Contently these links are updated more often and are considered the official version now.

### Possible Drawbacks

I can think about any.

### Verification Process

- Searched for any "codex" occurrence
- Replaced with the related page in the new docs

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes #328 

### Changelog Entry

`Updated Codex links in PHP section`
