### PR TITLE
fix: license reference in package.json from ISC to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/10up/Engineering-Best-Practices.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/10up/Engineering-Best-Practices/issues"
   },


### PR DESCRIPTION
See MIT as current license in repo: https://github.com/10up/Engineering-Best-Practices/blob/gh-pages/LICENSE.md

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

I noticed that we incorrectly list `ISC` as the license in the `package.json` file whereas MIT is the actual license in the report: https://github.com/10up/Engineering-Best-Practices/blob/gh-pages/LICENSE.md.  This PR corrects the `package.json` file to reference `MIT`.

### Alternate Designs

n/a

### Benefits

Ensures we correctly represent the licensing for this work.

### Possible Drawbacks

None identified unless someone purposely only utilizes these best practices because it was "licensed" ISC on Packagist?  Seems unlikely, but I suppose a possible drawback.

### Verification Process

Manually verified via the GitHub Desktop UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
n/a