### PR TITLE
Update URL references

### DIFF
--- a/_includes/markdown/JavaScript.md
+++ b/_includes/markdown/JavaScript.md
@@ -1,6 +1,6 @@
 <h2 id="code-style" class="anchor-heading">Code Style, Tooling & Documentation {% include Util/link_anchor anchor="code-style" %} {% include Util/top %}</h2>
 
-10up maintains a [eslint shareable config](https://github.com/10up/eslint-config) that is used across all 10up projects. It exposes several different configs and engineers should opt-in to the config that best fits the project. We also maintain a [babel-preset](https://github.com/10up/babel-preset-default/) that works well for most of our projects.
+10up maintains a [eslint shareable config](https://github.com/10up/10up-toolkit/tree/develop/packages/eslint-config) that is used across all 10up projects. It exposes several different configs and engineers should opt-in to the config that best fits the project. We also maintain a [babel-preset](https://github.com/10up/10up-toolkit/tree/develop/packages/babel-preset-default) that works well for most of our projects.
 
 As far as JavaScript documentation goes, we conform to the [WordPress JavaScript documentation standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/) and those standards are enforced by 10up's eslint config.
 


### PR DESCRIPTION
### Description of the Change

The links to eslint and babel-preset were pointing at archived repos. This PR updates these links.

- Update eslint link to: https://github.com/10up/10up-toolkit/tree/develop/packages/eslint-config
- Update babel-preset to: https://github.com/10up/10up-toolkit/tree/develop/packages/babel-preset-default

### How to test the Change
Review .md file.

### Changelog Entry

> Fixed - References to archived repos.

### Credits

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
