### PR TITLE
- including strict param in in_array

### DIFF
--- a/_includes/markdown/PHP.md
+++ b/_includes/markdown/PHP.md
@@ -63,7 +63,7 @@ Here are a few key points:
   if ( $foo_query->have_posts() ) :
       while ( $foo_query->have_posts() ) :
           $foo_query->the_post();
-          if ( in_array( get_the_ID(), $posts_to_exclude ) ) {
+          if ( in_array( get_the_ID(), $posts_to_exclude, true ) ) {
               continue;
           }
           the_title();


### PR DESCRIPTION
Included third parameter for in_array example to adhere to the guide in the next section (https://10up.github.io/Engineering-Best-Practices/php/#build-arrays-that-encourage-lookup-by-key-instead-of-search-by-value):

_"In case you don't have control over the array creation process and are forced to use `in_array()`, to improve the performance slightly, you should always set the third parameter to `true` to force use of strict comparison."_