### PR TITLE
Change max_post_size to post_max_size

### DIFF
--- a/_includes/markdown/Systems.md
+++ b/_includes/markdown/Systems.md
@@ -94,7 +94,7 @@ The following are settings in the ```php.ini``` file that commonly are adjusted 
 
 * **upload_max_filesize**: This will be the largest file size that can be uploaded to WordPress, usually through the media library. While a large value can increase the risk of certain type of flood attacks, these are uncommon and uploading media is a core business requirement of many sites, so it is generally considered safe to increase this as high as needed. When using Nginx, the ```client_max_body_size``` should be set to the same size as ```upload_max_filesize```.  Additionally, CDNs such as Cloudflare can have an adjustable upload limit as well. Consider all media types when setting this value as audio and video can be several hundred megabytes.
 
-* **max_post_size**: Needs to be as large or larger than ```upload_max_filesize```. This will be the maximum size of data sent through the POST method.
+* **post_max_size**: Needs to be as large or larger than ```upload_max_filesize```. This will be the maximum size of data sent through the POST method.
 
 * **date.timezone**: Set this to the main timezone of the admins of a WordPress site. It doesn’t much matter what this is set to, but some functions will work better when this value is set.
 


### PR DESCRIPTION
### Description of the Change
This has been in here wrong for years, but per https://www.php.net/manual/en/ini.core.php#ini.post-max-size, should be post_max_size and not max_post_size.

### How to test the Change
Just a text change that can be validated by reading https://www.php.net/manual/en/ini.core.php#ini.post-max-size

### Changelog Entry
Fixed = post_max_size typo


### Credits
Props @cmmarslender


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ x] I have updated the documentation accordingly.
