### PR TITLE
Fix broken URL to Performance Lab plugin

### DIFF
--- a/_includes/markdown/Performance.md
+++ b/_includes/markdown/Performance.md
@@ -93,7 +93,7 @@ The "[decoding](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElemen
 
 To improve your website's loading time, you’ll likely need to optimize the LCP element, which is typically the most prominent and first [image](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority) on the page. Factors such as [First Contentful Paint](https://web.dev/fcp), [Time to First Byte](https://web.dev/ttfb/), and render-blocking CSS/JS can cause an image to be flagged as the LCP element. 
 
-We can set a [fetch priority](https://addyosmani.com/blog/fetch-priority/) on the resource to load the image faster. The attribute hints to the browser that it should prioritize the fetch of the image relative to other images. The [Performance Lab plugin](http://g/plugins/performance-lab/) offers this functionality as a experimental option.
+We can set a [fetch priority](https://addyosmani.com/blog/fetch-priority/) on the resource to load the image faster. The attribute hints to the browser that it should prioritize the fetch of the image relative to other images. The [Performance Lab plugin](https://wordpress.org/plugins/performance-lab/) offers this functionality as a experimental option.
 
 ```html
 <img


### PR DESCRIPTION
### Description of the Change

The Performance page has a broken link to the Performance Lab plugin on wordpress.org.

* Broken: `http://g/plugins/performance-lab/`
* Fixed: `https://wordpress.org/plugins/performance-lab/`


### Changelog Entry

> Fixed - Corrected broken link to Performance Lab plugin


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] ~~I have updated the documentation accordingly.~~ - Not applicable
- [ ] ~~I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.~~ - Not applicable
- [x] All new and existing tests pass.
